### PR TITLE
Add capability to do a ROS build with cross SDK

### DIFF
--- a/config.sh.in
+++ b/config.sh.in
@@ -48,6 +48,9 @@ use_comedi=false
 use_ros=false
 use_can=false
 use_custom_application=false
+use_toolchain_file=false
+use_cross_compilation_environment=false
+use_ros_setup_script=false
 
 custom_application_name=simple-motor-control
 
@@ -246,4 +249,27 @@ rm_build_install_dir=false
 target_IP_address=192.168.7.2
 target_username=root
 target_application_folder=/opt/eeros/
+
+
+
+
+
+# variables for cross compilation environment
+#------------------------------------------------------------------------------
+# The "environment_setup_script" variable specifies the script of the cross
+# compilation SDK, which is sourced during running "make.sh" script. Typically,
+# the SDK script sets the needed environment variables in the current shell session.
+
+environment_setup_script=/opt/tdx-xwayland/5.0.0/environment-setup-armv7at2hf-neon-tdx-linux-gnueabi
+
+
+
+
+
+# ros setup script
+#------------------------------------------------------------------------------
+# The "ros_setup_script" variable specifies the ROS setup script which is sourced
+# during running "make.sh" script.
+
+ros_setup_script=/opt/tdx-xwayland/5.0.0/sysroots/armv7at2hf-neon-tdx-linux-gnueabi/opt/ros/melodic/setup.bash
 

--- a/make.sh
+++ b/make.sh
@@ -19,17 +19,39 @@ function build ()
   shift 2
   local flags="$@"
 
+  if [ "$use_toolchain_file" = true ]; then
+    flags="-DCMAKE_TOOLCHAIN_FILE=$toolchain_file $flags"
+  fi
+
   mkdir -p "$build_dir"
   pushd "$build_dir"
-  cmake -DCMAKE_TOOLCHAIN_FILE="$toolchain_file" \
-        -DCMAKE_INSTALL_PREFIX="$install_dir" \
+
+  cmake -DCMAKE_INSTALL_PREFIX="$install_dir" \
         -DCMAKE_BUILD_TYPE=Release \
         $flags \
         "$source_dir"
+
   $MAKE
   $MAKE install
   popd
 }
+
+
+if [ "$use_cross_compilation_environment" = true ]; then
+  . "$environment_setup_script"
+fi
+
+
+if [ "$use_ros_setup_script" = true ]; then
+  . "$ros_setup_script"
+fi
+
+
+# workaround to correctly setup environment when both of them are used
+if [ "$use_cross_compilation_environment" = true -a "$use_ros_setup_script" = true ]; then
+  unset LD_LIBRARY_PATH
+  . "$environment_setup_script"
+fi
 
 
 if [ "$use_can" = true ]; then


### PR DESCRIPTION
With this change, the build scripts are capable to
build EEROS with ROS using a cross toolchain containing
also the ROS libraries and tools.
For example a build with an SDK of a Yocto Linux